### PR TITLE
Show issue with serialization when upgrading to Spring Boot 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.15.0</version>
+                <version>2.15.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.13.5</version>
+                <version>2.15.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,123 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Spring Boot -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <type>pom</type>
+                <scope>import</scope>
+                <version>2.7.12</version>
+            </dependency>
+
+            <!-- Logging -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.36</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.2.11</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback.contrib</groupId>
+                <artifactId>logback-jackson</artifactId>
+                <version>0.1.5</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback.contrib</groupId>
+                <artifactId>logback-json-classic</artifactId>
+                <version>0.1.5</version>
+            </dependency>
+
+            <!-- Utils & Operations -->
+            <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>2.0.1.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>org.openapitools</groupId>
+                <artifactId>jackson-databind-nullable</artifactId>
+                <version>0.2.6</version>
+            </dependency>
+
+            <!-- Test -->
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.24.2</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Spring Boot -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Security -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-json-classic</artifactId>
+        </dependency>
+
+        <!-- Utils & Operations -->
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <resources>
             <resource>
@@ -36,6 +153,26 @@
                 <filtering>true</filtering>
             </testResource>
         </testResources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.7.12</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build-info</goal>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,13 @@
         <dependencies>
             <!-- Spring Boot -->
             <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.13.5</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -23,19 +23,19 @@
                 <artifactId>spring-boot-dependencies</artifactId>
                 <type>pom</type>
                 <scope>import</scope>
-                <version>2.7.12</version>
+                <version>3.1.0</version>
             </dependency>
 
             <!-- Logging -->
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.36</version>
+                <version>2.0.7</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.2.11</version>
+                <version>1.4.8</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback.contrib</groupId>
@@ -50,9 +50,9 @@
 
             <!-- Utils & Operations -->
             <dependency>
-                <groupId>javax.validation</groupId>
-                <artifactId>validation-api</artifactId>
-                <version>2.0.1.Final</version>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>3.0.2</version>
             </dependency>
             <dependency>
                 <groupId>org.openapitools</groupId>
@@ -111,8 +111,8 @@
 
         <!-- Utils & Operations -->
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.openapitools</groupId>

--- a/src/main/java/tk/dmanstrator/sb3_serialization_test/Application.java
+++ b/src/main/java/tk/dmanstrator/sb3_serialization_test/Application.java
@@ -1,0 +1,13 @@
+package tk.dmanstrator.sb3_serialization_test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(final String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/src/main/java/tk/dmanstrator/sb3_serialization_test/entity/CustomObject.java
+++ b/src/main/java/tk/dmanstrator/sb3_serialization_test/entity/CustomObject.java
@@ -1,0 +1,6 @@
+package tk.dmanstrator.sb3_serialization_test.entity;
+
+import java.io.Serializable;
+import java.util.List;
+
+public record CustomObject(String hello, List<String> world) implements Serializable {}

--- a/src/main/java/tk/dmanstrator/sb3_serialization_test/entity/CustomObject.java
+++ b/src/main/java/tk/dmanstrator/sb3_serialization_test/entity/CustomObject.java
@@ -1,57 +1,6 @@
 package tk.dmanstrator.sb3_serialization_test.entity;
 
-import java.io.Serial;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
-public class CustomObject implements Serializable {
-
-    @Serial
-    private static final long serialVersionUID = 0L;
-
-    private final String hello;
-    private final List<String> world;
-
-    // Default Constructor needed for (de)serialization.
-    public CustomObject() {
-        this("", new ArrayList<>());
-    }
-
-    public CustomObject(String hello, List<String> world) {
-        this.hello = hello;
-        this.world = world;
-    }
-
-    public String getHello() {
-        return hello;
-    }
-
-    public List<String> getWorld() {
-        return world;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == this) return true;
-        if (obj == null || obj.getClass() != this.getClass()) return false;
-        var that = (CustomObject) obj;
-        return Objects.equals(this.hello, that.hello) &&
-                Objects.equals(this.world, that.world);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(hello, world);
-    }
-
-    @Override
-    public String toString() {
-        return "CustomObject{" +
-                "hello='" + hello + '\'' +
-                ", world=" + world +
-                '}';
-    }
-
-}
+public record CustomObject(String hello, List<String> world) implements Serializable {}

--- a/src/main/java/tk/dmanstrator/sb3_serialization_test/entity/CustomObject.java
+++ b/src/main/java/tk/dmanstrator/sb3_serialization_test/entity/CustomObject.java
@@ -1,6 +1,57 @@
 package tk.dmanstrator.sb3_serialization_test.entity;
 
+import java.io.Serial;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
-public record CustomObject(String hello, List<String> world) implements Serializable {}
+public class CustomObject implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 0L;
+
+    private final String hello;
+    private final List<String> world;
+
+    // Default Constructor needed for (de)serialization.
+    public CustomObject() {
+        this("", new ArrayList<>());
+    }
+
+    public CustomObject(String hello, List<String> world) {
+        this.hello = hello;
+        this.world = world;
+    }
+
+    public String getHello() {
+        return hello;
+    }
+
+    public List<String> getWorld() {
+        return world;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (CustomObject) obj;
+        return Objects.equals(this.hello, that.hello) &&
+                Objects.equals(this.world, that.world);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hello, world);
+    }
+
+    @Override
+    public String toString() {
+        return "CustomObject{" +
+                "hello='" + hello + '\'' +
+                ", world=" + world +
+                '}';
+    }
+
+}

--- a/src/main/java/tk/dmanstrator/sb3_serialization_test/exporter/EntityExporter.java
+++ b/src/main/java/tk/dmanstrator/sb3_serialization_test/exporter/EntityExporter.java
@@ -1,0 +1,22 @@
+package tk.dmanstrator.sb3_serialization_test.exporter;
+
+import tk.dmanstrator.sb3_serialization_test.entity.CustomObject;
+import tk.dmanstrator.sb3_serialization_test.serialization.SerializationHandlerFactory;
+
+import java.io.IOException;
+
+/**
+ * Class responsible for exporting entities.
+ */
+public class EntityExporter {
+
+    private EntityExporter() {
+        // hide default constructor
+    }
+
+    public static String exportCustomObject(final CustomObject customObject) throws IOException {
+        return SerializationHandlerFactory.getDefaultHandlerWithPrettyPrint()
+                .writeObjectAsString(customObject);
+    }
+
+}

--- a/src/main/java/tk/dmanstrator/sb3_serialization_test/serialization/SerializationHandler.java
+++ b/src/main/java/tk/dmanstrator/sb3_serialization_test/serialization/SerializationHandler.java
@@ -1,0 +1,22 @@
+package tk.dmanstrator.sb3_serialization_test.serialization;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+
+public interface SerializationHandler {
+
+    boolean isBinary();
+
+    String getFileNameExtension();
+
+    <T extends Serializable> void writeObject(final T object, final OutputStream os) throws IOException;
+
+    <T extends Serializable> String writeObjectAsString(final T object) throws IOException;
+
+    <T extends Serializable> T readObject(final Class<T> clazz, final InputStream is) throws IOException;
+
+    <T extends Serializable> T readObjectFromString(final Class<T> clazz, final String input) throws IOException;
+
+}

--- a/src/main/java/tk/dmanstrator/sb3_serialization_test/serialization/SerializationHandlerFactory.java
+++ b/src/main/java/tk/dmanstrator/sb3_serialization_test/serialization/SerializationHandlerFactory.java
@@ -1,0 +1,20 @@
+package tk.dmanstrator.sb3_serialization_test.serialization;
+
+import tk.dmanstrator.sb3_serialization_test.serialization.impl.JsonSerializationHandler;
+
+public final class SerializationHandlerFactory {
+
+    private static final SerializationHandler DEFAULT_HANDLER = new JsonSerializationHandler(false);
+    private static final SerializationHandler DEFAULT_HANDLER_WITH_PRETTY_PRINT = new JsonSerializationHandler(true);
+
+    private SerializationHandlerFactory() {}
+
+    public static SerializationHandler getDefaultHandler() {
+        return DEFAULT_HANDLER;
+    }
+
+    public static SerializationHandler getDefaultHandlerWithPrettyPrint() {
+        return DEFAULT_HANDLER_WITH_PRETTY_PRINT;
+    }
+
+}

--- a/src/main/java/tk/dmanstrator/sb3_serialization_test/serialization/impl/AbstractJsonSerializationHandler.java
+++ b/src/main/java/tk/dmanstrator/sb3_serialization_test/serialization/impl/AbstractJsonSerializationHandler.java
@@ -1,0 +1,101 @@
+package tk.dmanstrator.sb3_serialization_test.serialization.impl;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import tk.dmanstrator.sb3_serialization_test.serialization.SerializationHandler;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public abstract class AbstractJsonSerializationHandler implements SerializationHandler {
+
+    protected static final ThreadLocal<ObjectMapper> OBJECT_MAPPER_THREAD_LOCAL =
+            ThreadLocal.withInitial(AbstractJsonSerializationHandler::newObjectMapper);
+
+    private final Map<Class<?>, ObjectReader> readers = new ConcurrentHashMap<>();
+    private final Map<Class<?>, ObjectWriter> writers = new ConcurrentHashMap<>();
+
+    private final boolean doPrettyPrint;
+
+    protected AbstractJsonSerializationHandler(final boolean doPrettyPrint) {
+        this.doPrettyPrint = doPrettyPrint;
+    }
+
+    @Override
+    public <T extends Serializable> void writeObject(final T object, final OutputStream os) throws IOException {
+        ObjectWriter writer = getWriter(object.getClass());
+
+        if (doPrettyPrint) {
+            writer = writer.withDefaultPrettyPrinter();
+        }
+
+        writer.writeValue(os, object);
+    }
+
+    @Override
+    public <T extends Serializable> String writeObjectAsString(final T object) throws IOException {
+        ObjectWriter writer = getWriter(object.getClass());
+
+        if (doPrettyPrint) {
+            writer = writer.withDefaultPrettyPrinter();
+        }
+
+        return writer.writeValueAsString(object);
+    }
+
+    @Override
+    public <T extends Serializable> T readObject(final Class<T> clazz, final InputStream is) throws IOException {
+        return getReader(clazz).readValue(is);
+    }
+
+    @Override
+    public <T extends Serializable> T readObjectFromString(final Class<T> clazz, final String input)
+            throws IOException {
+        return getReader(clazz).readValue(input);
+    }
+
+    private static ObjectMapper newObjectMapper() {
+        final PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator
+                .builder()
+                .allowIfBaseType(List.class)
+                .allowIfBaseType(Map.class)
+                .allowIfBaseType(Set.class)
+                .allowIfSubType(List.class)
+                .allowIfSubType(Map.class)
+                .build();
+        return JsonMapper.builder()
+                .enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES)
+                .activateDefaultTyping(ptv)
+                .addModule(new JavaTimeModule())
+                .addModule(new Jdk8Module())
+                .visibility(PropertyAccessor.ALL, Visibility.NONE)
+                .visibility(PropertyAccessor.FIELD, Visibility.ANY)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .serializationInclusion(Include.NON_NULL)
+                .build();
+    }
+
+    protected abstract ObjectMapper createObjectMapper();
+
+    private ObjectReader getReader(final Class<?> clazz) {
+        return readers.computeIfAbsent(clazz, c -> OBJECT_MAPPER_THREAD_LOCAL.get().readerFor(c));
+    }
+
+    private ObjectWriter getWriter(final Class<?> clazz) {
+        return writers.computeIfAbsent(clazz, c -> OBJECT_MAPPER_THREAD_LOCAL.get().writerFor(c));
+    }
+
+}

--- a/src/main/java/tk/dmanstrator/sb3_serialization_test/serialization/impl/JsonSerializationHandler.java
+++ b/src/main/java/tk/dmanstrator/sb3_serialization_test/serialization/impl/JsonSerializationHandler.java
@@ -1,0 +1,42 @@
+package tk.dmanstrator.sb3_serialization_test.serialization.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class JsonSerializationHandler extends AbstractJsonSerializationHandler {
+
+    /**
+     * Creates a new JSON Serializer. Won't apply pretty-printing when writing objects.
+     */
+    public JsonSerializationHandler() {
+        this(false);
+    }
+
+    /**
+     * Creates a new JSON Serializer.
+     *
+     * @param doPrettyPrint Flag to tell whether pretty-printing should be performed when writing objects or not.
+     */
+    public JsonSerializationHandler(final boolean doPrettyPrint) {
+        super(doPrettyPrint);
+    }
+
+    @Override
+    public boolean isBinary() {
+        return false;
+    }
+
+    @Override
+    public String getFileNameExtension() {
+        return ".json";
+    }
+
+    public static ObjectMapper getStandardObjectMapper() {
+        return OBJECT_MAPPER_THREAD_LOCAL.get();
+    }
+
+    @Override
+    protected ObjectMapper createObjectMapper() {
+        return new ObjectMapper();
+    }
+
+}

--- a/src/test/java/tk/dmanstrator/sb3_serialization_test/exporter/EntityExporterTest.java
+++ b/src/test/java/tk/dmanstrator/sb3_serialization_test/exporter/EntityExporterTest.java
@@ -1,0 +1,23 @@
+package tk.dmanstrator.sb3_serialization_test.exporter;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import tk.dmanstrator.sb3_serialization_test.entity.CustomObject;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+class EntityExporterTest {
+
+    private static final String EMPTY_JSON = "{ }";
+
+    @Test
+    void testExportCustomObject() throws IOException {
+        final CustomObject customObject = new CustomObject("hello", Arrays.asList("wor", "ld"));
+        final String json = EntityExporter.exportCustomObject(customObject);
+        Assertions.assertThat(json)
+                .isNotEmpty()
+                .isNotEqualTo(EMPTY_JSON);
+    }
+
+}


### PR DESCRIPTION
When using Spring Boot 2.7.12, the class can be serialized. With Spring Boot 3.1.0, this is not the case anymore (see failing test in the Checks).

It seems that the issue is, that the entity is a record. However, with Spring Boot 2.7.12, this was working.